### PR TITLE
Feat: New function strategy

### DIFF
--- a/src/__tests__/arrays.a.spec.ts
+++ b/src/__tests__/arrays.a.spec.ts
@@ -87,7 +87,7 @@ describe('Array assignment (left side)', () => {
     })
     it('should compile: Support for array notation on pointer variable.', () => {
         const code = '#pragma optimizationLevel 0\nlong b; void teste(long * poper) { poper[3]=0; }'
-        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare b\n^declare teste_poper\n\nFIN\n\n__fn_teste:\nPOP @teste_poper\nCLR @r0\nSET @r1 #0000000000000003\nSET @($teste_poper + $r1) $r0\nRET\n'
+        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare b\n^declare teste_poper\n\nFIN\n\n__fn_teste:\nCLR @r0\nSET @r1 #0000000000000003\nSET @($teste_poper + $r1) $r0\nRET\n'
         const compiler = new SmartC({ language: 'C', sourceCode: code })
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)

--- a/src/__tests__/functions.a.spec.ts
+++ b/src/__tests__/functions.a.spec.ts
@@ -24,7 +24,7 @@ describe('Special functions', () => {
     })
     it('should compile: catch() regular use', () => {
         const code = '#pragma optimizationLevel 0\n#program activationAmount 0\nlong table[20];\nvoid main (void) { const long a = 0; while (true) { table[a] = fibbonacci(a); halt; a++; } }\nlong fibbonacci(long n) { if(n == 0){ return 0; } else if(n == 1) { return 1; } else { return (fibbonacci(n-1) + fibbonacci(n-2)); } }\nvoid catch(void) { long a++; }'
-        const assembly = '^program activationAmount 0\n^declare r0\n^declare r1\n^declare r2\n^declare table\n^const SET @table #0000000000000004\n^declare table_0\n^declare table_1\n^declare table_2\n^declare table_3\n^declare table_4\n^declare table_5\n^declare table_6\n^declare table_7\n^declare table_8\n^declare table_9\n^declare table_10\n^declare table_11\n^declare table_12\n^declare table_13\n^declare table_14\n^declare table_15\n^declare table_16\n^declare table_17\n^declare table_18\n^declare table_19\n^declare main_a\n^declare fibbonacci_n\n^declare catch_a\n\nERR :__fn_catch\nJMP :__fn_main\n\n__fn_main:\nPCS\n^const SET @main_a #0000000000000000\n__loop1_continue:\n__loop1_start:\nPSH $main_a\nJSR :__fn_fibbonacci\nPOP @r0\nSET @($table + $main_a) $r0\nSTP\nINC @main_a\nJMP :__loop1_continue\n__loop1_break:\nFIN\n\n__fn_fibbonacci:\nPOP @fibbonacci_n\nBNZ $fibbonacci_n :__if2_else\n__if2_start:\nCLR @r0\nPSH $r0\nRET\nJMP :__if2_endif\n__if2_else:\nSET @r0 #0000000000000001\nBNE $fibbonacci_n $r0 :__if3_else\n__if3_start:\nSET @r0 #0000000000000001\nPSH $r0\nRET\nJMP :__if3_endif\n__if3_else:\nPSH $fibbonacci_n\nSET @r0 $fibbonacci_n\nDEC @r0\nPSH $r0\nJSR :__fn_fibbonacci\nPOP @r0\nPOP @fibbonacci_n\nPSH $fibbonacci_n\nPSH $r0\nSET @r1 $fibbonacci_n\nSET @r2 #0000000000000002\nSUB @r1 $r2\nPSH $r1\nJSR :__fn_fibbonacci\nPOP @r1\nPOP @r0\nPOP @fibbonacci_n\nADD @r0 $r1\nPSH $r0\nRET\n__if3_endif:\n__if2_endif:\nCLR @r0\nPSH $r0\nRET\n\n__fn_catch:\nPCS\nINC @catch_a\nFIN\n'
+        const assembly = '^program activationAmount 0\n^declare r0\n^declare r1\n^declare r2\n^declare table\n^const SET @table #0000000000000004\n^declare table_0\n^declare table_1\n^declare table_2\n^declare table_3\n^declare table_4\n^declare table_5\n^declare table_6\n^declare table_7\n^declare table_8\n^declare table_9\n^declare table_10\n^declare table_11\n^declare table_12\n^declare table_13\n^declare table_14\n^declare table_15\n^declare table_16\n^declare table_17\n^declare table_18\n^declare table_19\n^declare main_a\n^declare fibbonacci_n\n^declare catch_a\n\nERR :__fn_catch\nJMP :__fn_main\n\n__fn_main:\nPCS\n^const SET @main_a #0000000000000000\n__loop1_continue:\n__loop1_start:\nSET @fibbonacci_n $main_a\nJSR :__fn_fibbonacci\nSET @r0 $r0\nSET @($table + $main_a) $r0\nSTP\nINC @main_a\nJMP :__loop1_continue\n__loop1_break:\nFIN\n\n__fn_fibbonacci:\nBNZ $fibbonacci_n :__if2_else\n__if2_start:\nCLR @r0\nSET @r0 $r0\nRET\nJMP :__if2_endif\n__if2_else:\nSET @r0 #0000000000000001\nBNE $fibbonacci_n $r0 :__if3_else\n__if3_start:\nSET @r0 #0000000000000001\nSET @r0 $r0\nRET\nJMP :__if3_endif\n__if3_else:\nPSH $fibbonacci_n\nSET @r0 $fibbonacci_n\nDEC @r0\nSET @fibbonacci_n $r0\nJSR :__fn_fibbonacci\nSET @r0 $r0\nPOP @fibbonacci_n\nPSH $fibbonacci_n\nPSH $r0\nSET @r1 $fibbonacci_n\nSET @r2 #0000000000000002\nSUB @r1 $r2\nSET @fibbonacci_n $r1\nJSR :__fn_fibbonacci\nSET @r1 $r0\nPOP @r0\nPOP @fibbonacci_n\nADD @r0 $r1\nSET @r0 $r0\nRET\n__if3_endif:\n__if2_endif:\nRET\n\n__fn_catch:\nPCS\nINC @catch_a\nFIN\n'
         const compiler = new SmartC({ language: 'C', sourceCode: code })
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)
@@ -90,28 +90,28 @@ describe('User defined functions', () => {
     })
     it('should compile: definition: fun(argument)', () => {
         const code = '#pragma optimizationLevel 0\nlong a; void test2(long b) { b++; return; }'
-        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare a\n^declare test2_b\n\nFIN\n\n__fn_test2:\nPOP @test2_b\nINC @test2_b\nRET\n'
+        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare a\n^declare test2_b\n\nFIN\n\n__fn_test2:\nINC @test2_b\nRET\n'
         const compiler = new SmartC({ language: 'C', sourceCode: code })
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)
     })
     it('should compile: passing values in argument', () => {
         const code = '#pragma optimizationLevel 0\nlong a; long test2(long b) { b++; return b; }'
-        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare a\n^declare test2_b\n\nFIN\n\n__fn_test2:\nPOP @test2_b\nINC @test2_b\nPSH $test2_b\nRET\n'
+        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare a\n^declare test2_b\n\nFIN\n\n__fn_test2:\nINC @test2_b\nSET @r0 $test2_b\nRET\n'
         const compiler = new SmartC({ language: 'C', sourceCode: code })
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)
     })
     it('should compile: passing values and getting return value', () => {
         const code = '#pragma optimizationLevel 0\nlong a=0; a=test2(a); long test2(long b) { b++; return b; }'
-        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare a\n^declare test2_b\n\nCLR @a\nPSH $a\nJSR :__fn_test2\nPOP @r0\nSET @a $r0\nFIN\n\n__fn_test2:\nPOP @test2_b\nINC @test2_b\nPSH $test2_b\nRET\n'
+        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare a\n^declare test2_b\n\nCLR @a\nSET @test2_b $a\nJSR :__fn_test2\nSET @r0 $r0\nSET @a $r0\nFIN\n\n__fn_test2:\nINC @test2_b\nSET @r0 $test2_b\nRET\n'
         const compiler = new SmartC({ language: 'C', sourceCode: code })
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)
     })
     it('should compile: Ununsed function after main() (unreacheable code)', () => {
         const code = '#pragma optimizationLevel 0\nlong a=0; void main(void){ a++; test2(a); exit; } void test2(long b) { b++; return; }'
-        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare a\n^declare test2_b\n\nCLR @a\nJMP :__fn_main\n\n__fn_main:\nPCS\nINC @a\nPSH $a\nJSR :__fn_test2\nFIN\n\n__fn_test2:\nPOP @test2_b\nINC @test2_b\nRET\n'
+        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare a\n^declare test2_b\n\nCLR @a\nJMP :__fn_main\n\n__fn_main:\nPCS\nINC @a\nSET @test2_b $a\nJSR :__fn_test2\nFIN\n\n__fn_test2:\nINC @test2_b\nRET\n'
         const compiler = new SmartC({ language: 'C', sourceCode: code })
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)
@@ -125,7 +125,7 @@ describe('User defined functions', () => {
     })
     it('should compile: function returning long_ptr', () => {
         const code = '#pragma optimizationLevel 0\nlong *a; a=test(); long *test(void) { long b; return &b; }'
-        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare a\n^declare test_b\n\nJSR :__fn_test\nPOP @a\nFIN\n\n__fn_test:\nSET @r0 #0000000000000004\nPSH $r0\nRET\n'
+        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare a\n^declare test_b\n\nJSR :__fn_test\nSET @a $r0\nFIN\n\n__fn_test:\nSET @r0 #0000000000000004\nSET @r0 $r0\nRET\n'
         const compiler = new SmartC({ language: 'C', sourceCode: code })
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)
@@ -174,35 +174,35 @@ describe('User defined functions', () => {
     })
     it('should compile: check variable types on function arguments', () => {
         const code = '#pragma optimizationLevel 0\nlong * a, b; teste(a, b); void teste(long *fa, long fb) { fb++; }'
-        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare a\n^declare b\n^declare teste_fa\n^declare teste_fb\n\nPSH $b\nPSH $a\nJSR :__fn_teste\nFIN\n\n__fn_teste:\nPOP @teste_fa\nPOP @teste_fb\nINC @teste_fb\nRET\n'
+        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare a\n^declare b\n^declare teste_fa\n^declare teste_fb\n\nSET @teste_fb $b\nSET @teste_fa $a\nJSR :__fn_teste\nFIN\n\n__fn_teste:\nINC @teste_fb\nRET\n'
         const compiler = new SmartC({ language: 'C', sourceCode: code })
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)
     })
     it('should compile: check variable types on function arguments', () => {
         const code = '#pragma optimizationLevel 0\nlong * a, b; teste(a, *a); void teste(long *fa, long fb) { fb++; }'
-        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare a\n^declare b\n^declare teste_fa\n^declare teste_fb\n\nSET @r0 $($a)\nPSH $r0\nPSH $a\nJSR :__fn_teste\nFIN\n\n__fn_teste:\nPOP @teste_fa\nPOP @teste_fb\nINC @teste_fb\nRET\n'
+        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare a\n^declare b\n^declare teste_fa\n^declare teste_fb\n\nSET @teste_fb $($a)\nSET @teste_fa $a\nJSR :__fn_teste\nFIN\n\n__fn_teste:\nINC @teste_fb\nRET\n'
         const compiler = new SmartC({ language: 'C', sourceCode: code })
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)
     })
     it('should compile: check variable types on function arguments', () => {
         const code = '#pragma optimizationLevel 0\nlong * a, b; teste(&b, b); void teste(long *fa, long fb) { fb++; }'
-        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare a\n^declare b\n^declare teste_fa\n^declare teste_fb\n\nPSH $b\nSET @r0 #0000000000000004\nPSH $r0\nJSR :__fn_teste\nFIN\n\n__fn_teste:\nPOP @teste_fa\nPOP @teste_fb\nINC @teste_fb\nRET\n'
+        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare a\n^declare b\n^declare teste_fa\n^declare teste_fb\n\nSET @teste_fb $b\nSET @teste_fa #0000000000000004\nJSR :__fn_teste\nFIN\n\n__fn_teste:\nINC @teste_fb\nRET\n'
         const compiler = new SmartC({ language: 'C', sourceCode: code })
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)
     })
     it('should compile: pass two struct pointer as argument', () => {
         const code = '#pragma optimizationLevel 0\nstruct KOMBI { long driver, collector, passenger; } car1, car2; long a, b; test(&car1, &car2); void test(struct KOMBI * lptr, struct KOMBI * rptr) { lptr-> driver = rptr-> driver; }'
-        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare car1_driver\n^declare car1_collector\n^declare car1_passenger\n^declare car2_driver\n^declare car2_collector\n^declare car2_passenger\n^declare a\n^declare b\n^declare test_lptr\n^declare test_rptr\n\nSET @r0 #0000000000000006\nPSH $r0\nSET @r0 #0000000000000003\nPSH $r0\nJSR :__fn_test\nFIN\n\n__fn_test:\nPOP @test_lptr\nPOP @test_rptr\nSET @r0 $($test_rptr)\nSET @($test_lptr) $r0\nRET\n'
+        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare car1_driver\n^declare car1_collector\n^declare car1_passenger\n^declare car2_driver\n^declare car2_collector\n^declare car2_passenger\n^declare a\n^declare b\n^declare test_lptr\n^declare test_rptr\n\nSET @test_rptr #0000000000000006\nSET @test_lptr #0000000000000003\nJSR :__fn_test\nFIN\n\n__fn_test:\nSET @r0 $($test_rptr)\nSET @($test_lptr) $r0\nRET\n'
         const compiler = new SmartC({ language: 'C', sourceCode: code })
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)
     })
     it('should compile: pass struct pointer as second argument', () => {
         const code = '#pragma optimizationLevel 0\nstruct KOMBI { long driver, collector, passenger; } car; long a, b; test(a, &car); void test(long a, struct KOMBI * sptr) { sptr-> driver = a; }'
-        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare car_driver\n^declare car_collector\n^declare car_passenger\n^declare a\n^declare b\n^declare test_a\n^declare test_sptr\n\nSET @r0 #0000000000000003\nPSH $r0\nPSH $a\nJSR :__fn_test\nFIN\n\n__fn_test:\nPOP @test_a\nPOP @test_sptr\nSET @($test_sptr) $test_a\nRET\n'
+        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare car_driver\n^declare car_collector\n^declare car_passenger\n^declare a\n^declare b\n^declare test_a\n^declare test_sptr\n\nSET @test_sptr #0000000000000003\nSET @test_a $a\nJSR :__fn_test\nFIN\n\n__fn_test:\nSET @($test_sptr) $test_a\nRET\n'
         const compiler = new SmartC({ language: 'C', sourceCode: code })
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)
@@ -223,14 +223,14 @@ describe('User defined functions', () => {
     })
     it('should compile: check variable types on function arguments', () => {
         const code = "#pragma optimizationLevel 0\nstruct KOMBI { long driver; long collector; long passenger; } ;struct KOMBI car, *pcar;long a, b;pcar=&car;\n teste(pcar);\n void teste(struct KOMBI * value) { value->driver = 'Zé'; }"
-        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare car_driver\n^declare car_collector\n^declare car_passenger\n^declare pcar\n^declare a\n^declare b\n^declare teste_value\n\nSET @pcar #0000000000000003\nPSH $pcar\nJSR :__fn_teste\nFIN\n\n__fn_teste:\nPOP @teste_value\nSET @r0 #0000000000a9c35a\nSET @($teste_value) $r0\nRET\n'
+        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare car_driver\n^declare car_collector\n^declare car_passenger\n^declare pcar\n^declare a\n^declare b\n^declare teste_value\n\nSET @pcar #0000000000000003\nSET @teste_value $pcar\nJSR :__fn_teste\nFIN\n\n__fn_teste:\nSET @r0 #0000000000a9c35a\nSET @($teste_value) $r0\nRET\n'
         const compiler = new SmartC({ language: 'C', sourceCode: code })
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)
     })
     it('should compile: Passing long inside struct (with offset)', () => {
         const code = '#pragma optimizationLevel 0\nstruct KOMBI { long driver; long collector; long passenger; } ;struct KOMBI car[2]; long a;\nteste(car[a].collector);\n void teste(long value) { value++; }'
-        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare car\n^const SET @car #0000000000000004\n^declare car_0_driver\n^declare car_0_collector\n^declare car_0_passenger\n^declare car_1_driver\n^declare car_1_collector\n^declare car_1_passenger\n^declare a\n^declare teste_value\n\nSET @r0 #0000000000000003\nMUL @r0 $a\nINC @r0\nSET @r1 $($car + $r0)\nPSH $r1\nJSR :__fn_teste\nFIN\n\n__fn_teste:\nPOP @teste_value\nINC @teste_value\nRET\n'
+        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare car\n^const SET @car #0000000000000004\n^declare car_0_driver\n^declare car_0_collector\n^declare car_0_passenger\n^declare car_1_driver\n^declare car_1_collector\n^declare car_1_passenger\n^declare a\n^declare teste_value\n\nSET @r0 #0000000000000003\nMUL @r0 $a\nINC @r0\nSET @teste_value $($car + $r0)\nJSR :__fn_teste\nFIN\n\n__fn_teste:\nINC @teste_value\nRET\n'
         const compiler = new SmartC({ language: 'C', sourceCode: code })
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)
@@ -251,7 +251,7 @@ describe('User defined functions', () => {
     })
     it('should compile: Function returning struct pointer', () => {
         const code = '#pragma optimizationLevel 0\nstruct KOMBI { long driver, collector, passenger; } *val; val = teste(); val = test2(); struct KOMBI *teste(void) { struct KOMBI tt2; return &tt2; } struct KOMBI *test2(void) { struct KOMBI *stt2; return stt2; }'
-        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare val\n^declare teste_tt2_driver\n^declare teste_tt2_collector\n^declare teste_tt2_passenger\n^declare test2_stt2\n\nJSR :__fn_teste\nPOP @r0\nSET @val $r0\nJSR :__fn_test2\nPOP @r0\nSET @val $r0\nFIN\n\n__fn_teste:\nSET @r0 #0000000000000004\nPSH $r0\nRET\n\n__fn_test2:\nPSH $test2_stt2\nRET\n'
+        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare val\n^declare teste_tt2_driver\n^declare teste_tt2_collector\n^declare teste_tt2_passenger\n^declare test2_stt2\n\nJSR :__fn_teste\nSET @r0 $r0\nSET @val $r0\nJSR :__fn_test2\nSET @r0 $r0\nSET @val $r0\nFIN\n\n__fn_teste:\nSET @r0 #0000000000000004\nSET @r0 $r0\nRET\n\n__fn_test2:\nSET @r0 $test2_stt2\nRET\n'
         const compiler = new SmartC({ language: 'C', sourceCode: code })
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)
@@ -265,7 +265,7 @@ describe('User defined functions', () => {
     })
     it('should compile: Recursive functions', () => {
         const code = '#pragma optimizationLevel 0\nlong a; long counter = 0; a = fibbonacci(12); \nlong fibbonacci(long n) {if(n == 0){ return 0; } else if(n == 1) { return 1; } else { return (fibbonacci(n-1) + fibbonacci(n-2)); } }'
-        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare a\n^declare counter\n^declare fibbonacci_n\n\nCLR @counter\nSET @a #000000000000000c\nPSH $a\nJSR :__fn_fibbonacci\nPOP @a\nFIN\n\n__fn_fibbonacci:\nPOP @fibbonacci_n\nBNZ $fibbonacci_n :__if1_else\n__if1_start:\nCLR @r0\nPSH $r0\nRET\nJMP :__if1_endif\n__if1_else:\nSET @r0 #0000000000000001\nBNE $fibbonacci_n $r0 :__if2_else\n__if2_start:\nSET @r0 #0000000000000001\nPSH $r0\nRET\nJMP :__if2_endif\n__if2_else:\nPSH $fibbonacci_n\nSET @r0 $fibbonacci_n\nDEC @r0\nPSH $r0\nJSR :__fn_fibbonacci\nPOP @r0\nPOP @fibbonacci_n\nPSH $fibbonacci_n\nPSH $r0\nSET @r1 $fibbonacci_n\nSET @r2 #0000000000000002\nSUB @r1 $r2\nPSH $r1\nJSR :__fn_fibbonacci\nPOP @r1\nPOP @r0\nPOP @fibbonacci_n\nADD @r0 $r1\nPSH $r0\nRET\n__if2_endif:\n__if1_endif:\nCLR @r0\nPSH $r0\nRET\n'
+        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare a\n^declare counter\n^declare fibbonacci_n\n\nCLR @counter\nSET @fibbonacci_n #000000000000000c\nJSR :__fn_fibbonacci\nSET @a $r0\nFIN\n\n__fn_fibbonacci:\nBNZ $fibbonacci_n :__if1_else\n__if1_start:\nCLR @r0\nSET @r0 $r0\nRET\nJMP :__if1_endif\n__if1_else:\nSET @r0 #0000000000000001\nBNE $fibbonacci_n $r0 :__if2_else\n__if2_start:\nSET @r0 #0000000000000001\nSET @r0 $r0\nRET\nJMP :__if2_endif\n__if2_else:\nPSH $fibbonacci_n\nSET @r0 $fibbonacci_n\nDEC @r0\nSET @fibbonacci_n $r0\nJSR :__fn_fibbonacci\nSET @r0 $r0\nPOP @fibbonacci_n\nPSH $fibbonacci_n\nPSH $r0\nSET @r1 $fibbonacci_n\nSET @r2 #0000000000000002\nSUB @r1 $r2\nSET @fibbonacci_n $r1\nJSR :__fn_fibbonacci\nSET @r1 $r0\nPOP @r0\nPOP @fibbonacci_n\nADD @r0 $r1\nSET @r0 $r0\nRET\n__if2_endif:\n__if1_endif:\nRET\n'
         const compiler = new SmartC({ language: 'C', sourceCode: code })
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)
@@ -275,14 +275,14 @@ describe('User defined functions', () => {
 teste(pvoid, pvoid); teste(pvoid, pstruct); plong = ret(pvoid, plong); pstruct = ret(pvoid, plong);
 void teste( long *aa, void *bb) { aa++, bb++; }
 void *ret(long *aa, void *bb) { aa++; return aa; }`
-        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare pstruct\n^declare plong\n^declare pvoid\n^declare teste_aa\n^declare teste_bb\n^declare ret_aa\n^declare ret_bb\n\nPSH $pvoid\nPSH $pvoid\nJSR :__fn_teste\nPSH $pstruct\nPSH $pvoid\nJSR :__fn_teste\nPSH $plong\nPSH $pvoid\nJSR :__fn_ret\nPOP @r0\nSET @plong $r0\nPSH $plong\nPSH $pvoid\nJSR :__fn_ret\nPOP @r0\nSET @pstruct $r0\nFIN\n\n__fn_teste:\nPOP @teste_aa\nPOP @teste_bb\nINC @teste_aa\nINC @teste_bb\nRET\n\n__fn_ret:\nPOP @ret_aa\nPOP @ret_bb\nINC @ret_aa\nPSH $ret_aa\nRET\n'
+        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare pstruct\n^declare plong\n^declare pvoid\n^declare teste_aa\n^declare teste_bb\n^declare ret_aa\n^declare ret_bb\n\nSET @teste_bb $pvoid\nSET @teste_aa $pvoid\nJSR :__fn_teste\nSET @teste_bb $pstruct\nSET @teste_aa $pvoid\nJSR :__fn_teste\nSET @ret_bb $plong\nSET @ret_aa $pvoid\nJSR :__fn_ret\nSET @r0 $r0\nSET @plong $r0\nSET @ret_bb $plong\nSET @ret_aa $pvoid\nJSR :__fn_ret\nSET @r0 $r0\nSET @pstruct $r0\nFIN\n\n__fn_teste:\nINC @teste_aa\nINC @teste_bb\nRET\n\n__fn_ret:\nINC @ret_aa\nSET @r0 $ret_aa\nRET\n'
         const compiler = new SmartC({ language: 'C', sourceCode: code })
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)
     })
     it('should compile: function returning NULL pointer, return of long_ptr at function returning void pointer, Assign this return value to a long_ptr', () => {
         const code = '#pragma optimizationLevel 0\nlong *plong; plong = malloc(); void *malloc(void) { if (current >=20) { return NULL; } long current++; long mem[20]; return (&mem[current]); }'
-        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare plong\n^declare malloc_current\n^declare malloc_mem\n^const SET @malloc_mem #0000000000000006\n^declare malloc_mem_0\n^declare malloc_mem_1\n^declare malloc_mem_2\n^declare malloc_mem_3\n^declare malloc_mem_4\n^declare malloc_mem_5\n^declare malloc_mem_6\n^declare malloc_mem_7\n^declare malloc_mem_8\n^declare malloc_mem_9\n^declare malloc_mem_10\n^declare malloc_mem_11\n^declare malloc_mem_12\n^declare malloc_mem_13\n^declare malloc_mem_14\n^declare malloc_mem_15\n^declare malloc_mem_16\n^declare malloc_mem_17\n^declare malloc_mem_18\n^declare malloc_mem_19\n\nJSR :__fn_malloc\nPOP @plong\nFIN\n\n__fn_malloc:\nSET @r0 #0000000000000014\nBLT $malloc_current $r0 :__if1_endif\n__if1_start:\nCLR @r0\nPSH $r0\nRET\n__if1_endif:\nINC @malloc_current\nSET @r0 $malloc_mem\nADD @r0 $malloc_current\nPSH $r0\nRET\n'
+        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare plong\n^declare malloc_current\n^declare malloc_mem\n^const SET @malloc_mem #0000000000000006\n^declare malloc_mem_0\n^declare malloc_mem_1\n^declare malloc_mem_2\n^declare malloc_mem_3\n^declare malloc_mem_4\n^declare malloc_mem_5\n^declare malloc_mem_6\n^declare malloc_mem_7\n^declare malloc_mem_8\n^declare malloc_mem_9\n^declare malloc_mem_10\n^declare malloc_mem_11\n^declare malloc_mem_12\n^declare malloc_mem_13\n^declare malloc_mem_14\n^declare malloc_mem_15\n^declare malloc_mem_16\n^declare malloc_mem_17\n^declare malloc_mem_18\n^declare malloc_mem_19\n\nJSR :__fn_malloc\nSET @plong $r0\nFIN\n\n__fn_malloc:\nSET @r0 #0000000000000014\nBLT $malloc_current $r0 :__if1_endif\n__if1_start:\nCLR @r0\nSET @r0 $r0\nRET\n__if1_endif:\nINC @malloc_current\nSET @r0 $malloc_mem\nADD @r0 $malloc_current\nSET @r0 $r0\nRET\n'
         const compiler = new SmartC({ language: 'C', sourceCode: code })
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)

--- a/src/__tests__/macros.a.spec.ts
+++ b/src/__tests__/macros.a.spec.ts
@@ -96,7 +96,7 @@ describe('#program', () => {
     })
     it('should compile: codeStackPages  userStackPages ', () => {
         const code = '#pragma optimizationLevel 0\n#program codeStackPages    0   \n#program userStackPages 5\n long a; void test(long aa) { a++; return; a++; }'
-        const assembly = '^program userStackPages 5\n^declare r0\n^declare r1\n^declare r2\n^declare a\n^declare test_aa\n\nFIN\n\n__fn_test:\nPOP @test_aa\nINC @a\nRET\nINC @a\nRET\n'
+        const assembly = '^program userStackPages 5\n^declare r0\n^declare r1\n^declare r2\n^declare a\n^declare test_aa\n\nFIN\n\n__fn_test:\nINC @a\nRET\nINC @a\nRET\n'
         const compiler = new SmartC({ language: 'C', sourceCode: code })
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)

--- a/src/__tests__/misc.a.spec.ts
+++ b/src/__tests__/misc.a.spec.ts
@@ -4,7 +4,7 @@ describe('Miscelaneous', () => {
     it('should compile: Modifier on Function -> arr on pointer return value', () => {
         const code = 'long valLong = teste()[1]; long *teste(void) { long message[4]; return message; }'
         const assembly =
-            '^declare r0\n^declare r1\n^declare r2\n^declare valLong\n^declare teste_message\n^const SET @teste_message #0000000000000005\n^declare teste_message_0\n^declare teste_message_1\n^declare teste_message_2\n^declare teste_message_3\n\nJSR :__fn_teste\nPOP @valLong\nSET @r0 #0000000000000001\nSET @valLong $($valLong + $r0)\nFIN\n\n__fn_teste:\nPSH $teste_message\nRET\n'
+            '^declare r0\n^declare r1\n^declare r2\n^declare valLong\n^declare teste_message\n^const SET @teste_message #0000000000000005\n^declare teste_message_0\n^declare teste_message_1\n^declare teste_message_2\n^declare teste_message_3\n\nJSR :__fn_teste\nSET @valLong $r0\nSET @r0 #0000000000000001\nSET @valLong $($valLong + $r0)\nFIN\n\n__fn_teste:\nSET @r0 $teste_message\nRET\n'
         const compiler = new SmartC({ language: 'C', sourceCode: code })
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)

--- a/src/__tests__/optimizations.a.spec.ts
+++ b/src/__tests__/optimizations.a.spec.ts
@@ -148,9 +148,9 @@ describe('Optimizations level 2', () => {
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)
     })
-    it('should compile: Pop+Push', () => {
+    it('should compile: handling function return value as argument for another one', () => {
         const code = '#pragma optimizationLevel 2\n long a, b; tt(teste(b)); long teste(long c){ return ++c; } void tt(long d){ d++; }'
-        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare a\n^declare b\n^declare teste_c\n^declare tt_d\n\nPSH $b\nJSR :__fn_teste\nJSR :__fn_tt\nFIN\n\n__fn_teste:\nPOP @teste_c\nINC @teste_c\nPSH $teste_c\nRET\n\n__fn_tt:\nPOP @tt_d\nINC @tt_d\nRET\n'
+        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare a\n^declare b\n^declare teste_c\n^declare tt_d\n\nSET @teste_c $b\nJSR :__fn_teste\nSET @tt_d $r0\nJSR :__fn_tt\nFIN\n\n__fn_teste:\nINC @teste_c\nSET @r0 $teste_c\nRET\n\n__fn_tt:\nINC @tt_d\nRET\n'
         const compiler = new SmartC({ language: 'C', sourceCode: code })
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)

--- a/src/__tests__/structs.b.spec.ts
+++ b/src/__tests__/structs.b.spec.ts
@@ -195,7 +195,7 @@ struct PLAYER * search(long playerAddress) {
     nPlayers = sizeof(struct PLAYER);
     return NULL;
 }`
-        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare search_playerAddress\n^declare search_playerPtr\n^declare search_players\n^const SET @search_players #0000000000000006\n^declare search_players_0_address\n^declare search_players_0_balance\n^declare search_players_0_VDLS\n^declare search_players_1_address\n^declare search_players_1_balance\n^declare search_players_1_VDLS\n^declare search_nPlayers\n^declare search_foundPlayer\n\nSET @r0 #0000000000000002\nPSH $r0\nJSR :__fn_search\nPOP @r0\nFIN\n\n__fn_search:\nPOP @search_playerAddress\nSET @search_nPlayers #0000000000000003\nCLR @r0\nPSH $r0\nRET\n'
+        const assembly = '^declare r0\n^declare r1\n^declare r2\n^declare search_playerAddress\n^declare search_playerPtr\n^declare search_players\n^const SET @search_players #0000000000000006\n^declare search_players_0_address\n^declare search_players_0_balance\n^declare search_players_0_VDLS\n^declare search_players_1_address\n^declare search_players_1_balance\n^declare search_players_1_VDLS\n^declare search_nPlayers\n^declare search_foundPlayer\n\nSET @search_playerAddress #0000000000000002\nJSR :__fn_search\nFIN\n\n__fn_search:\nSET @search_nPlayers #0000000000000003\nCLR @r0\nRET\n'
         const compiler = new SmartC({ language: 'C', sourceCode: code })
         compiler.compile()
         expect(compiler.getAssemblyCode()).toBe(assembly)

--- a/src/codeGenerator/assemblyProcessor/assignmentToAsm.ts
+++ b/src/codeGenerator/assemblyProcessor/assignmentToAsm.ts
@@ -112,7 +112,7 @@ export default function assignmentToAsm (
     /** Left type is 'register', 'long' or 'structRef', with offset undefined. Right type is 'register', 'long', or
      * 'structRef' with offset undefined. Create assembly instruction. */
     function leftRegularOffsetUndefinedAndRightRegularOffsetUndefinedToAsm (): string {
-        if (Left.declaration !== Right.declaration) {
+        if (utils.isNotValidDeclarationOp(Left.declaration, Right)) {
             throw new Error(`Internal error at line: ${operationLine}.`)
         }
         if (Left.address === Right.address) {

--- a/src/codeGenerator/assemblyProcessor/createInstruction.ts
+++ b/src/codeGenerator/assemblyProcessor/createInstruction.ts
@@ -221,6 +221,16 @@ export function flattenMemory (
     return flattenMemoryMain()
 }
 
+/** Used in function calls. Mem shall be a memory not stuffed */
+export function forceSetMemFromR0 (AuxVars: GENCODE_AUXVARS, Mem: MEMORY_SLOT, line: number) {
+    const Temp = flattenMemory(AuxVars, Mem, line)
+    if (Temp.isNew) {
+        // Debug this, force set should be simple instruction
+        throw new Error('Internal error')
+    }
+    return Temp.asmCode + `SET @${Temp.FlatMem.asmName} $r0\n`
+}
+
 /** Translate one single instruction from ast to assembly code */
 export function createInstruction (
     AuxVars: GENCODE_AUXVARS, OperatorToken: TOKEN, MemParam1?: MEMORY_SLOT, MemParam2?: MEMORY_SLOT,

--- a/src/codeGenerator/assemblyProcessor/keywordToAsm.ts
+++ b/src/codeGenerator/assemblyProcessor/keywordToAsm.ts
@@ -26,7 +26,7 @@ export default function keywordToAsm (
             return 'RET\n'
         }
         TmpMemObj = flattenMemory(AuxVars, FlatMem, OperatorToken.line)
-        TmpMemObj.asmCode += `PSH $${TmpMemObj.FlatMem.asmName}\n`
+        TmpMemObj.asmCode += `SET @r0 $${TmpMemObj.FlatMem.asmName}\n`
         TmpMemObj.asmCode += 'RET\n'
         AuxVars.freeRegister(FlatMem.address)
         if (TmpMemObj.isNew === true) {

--- a/src/codeGenerator/astProcessor/functionSolver.ts
+++ b/src/codeGenerator/astProcessor/functionSolver.ts
@@ -3,7 +3,7 @@ import { CONTRACT, SC_FUNCTION } from '../../typings/contractTypes'
 import { LOOKUP_ASN, AST, MEMORY_SLOT } from '../../typings/syntaxTypes'
 import { createBuiltinInstruction } from '../assemblyProcessor/builtinToAsm'
 import {
-    createSimpleInstruction, createInstruction, createAPICallInstruction
+    createSimpleInstruction, createInstruction, createAPICallInstruction, forceSetMemFromR0
 } from '../assemblyProcessor/createInstruction'
 import { GENCODE_AUXVARS, GENCODE_ARGS, GENCODE_SOLVED_OBJECT } from '../codeGeneratorTypes'
 import utils from '../utils'
@@ -80,7 +80,8 @@ export default function functionSolver (
             returnAssemblyCode += ArgGenObj.asmCode
             returnAssemblyCode += createInstruction(
                 AuxVars,
-                utils.genPushToken(CurrentNode.Token.line),
+                utils.genAssignmentToken(CurrentNode.Token.line),
+                fnArg,
                 ArgGenObj.SolvedMem
             )
             AuxVars.freeRegister(ArgGenObj.SolvedMem.address)
@@ -94,7 +95,7 @@ export default function functionSolver (
             FnRetObj = AuxVars.getNewRegister()
             FnRetObj.declaration = FunctionToCall.declaration
             FnRetObj.typeDefinition = FunctionToCall.typeDefinition
-            returnAssemblyCode += createSimpleInstruction('Pop', FnRetObj.asmName)
+            returnAssemblyCode += forceSetMemFromR0(AuxVars, FnRetObj, CurrentNode.Token.line)
         }
         // Load registers again
         registerStack.reverse()

--- a/src/codeGenerator/codeGenerator.ts
+++ b/src/codeGenerator/codeGenerator.ts
@@ -158,9 +158,6 @@ export default function codeGenerator (Program: CONTRACT) {
             return
         }
         writeAsmLine(`__fn_${fname}:`, Program.functions[GlobalCodeVars.currFunctionIndex].line)
-        Program.functions[GlobalCodeVars.currFunctionIndex].argsMemObj.forEach(Obj => {
-            writeAsmLine(`POP @${Obj.asmName}`)
-        })
     }
 
     /**
@@ -175,13 +172,6 @@ export default function codeGenerator (Program: CONTRACT) {
             return
         }
         if (GlobalCodeVars.assemblyCode.lastIndexOf('RET') + 4 !== GlobalCodeVars.assemblyCode.length) {
-            if (Program.functions[GlobalCodeVars.currFunctionIndex].declaration === 'void') {
-                writeAsmLine('RET')
-                return
-            }
-            // return zero to prevent stack overflow
-            writeAsmLine('CLR @r0')
-            writeAsmLine('PSH $r0')
             writeAsmLine('RET')
         }
     }


### PR DESCRIPTION
Function variables are globally assigned, due to the fact there is no good way to interact with Signum User Stack. Actually only pushing and popping possible, and for a good use of it, it would be needed to set/read values from the stack without needing to removing them.

That said, there was no meaning to push and pop values if they are always assigned to the same variable, so this new strategy saves instructions cycles and in most of cases removes all stack operations. Without stack operations, the contracts can save one page of 'User Stack Page' on deployment, and also cost a little less for the execution.

The implementation continues to use stack if there is a recursive function, or if we need to save the registers from caller.

Dozens tests and also some simulations for the edge cases proves this is a good move.